### PR TITLE
add sharing_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ go build -o terraform-provider-gandi
 ## Example
 
 This example partly mimics the steps of [the official LiveDNS documentation example](http://doc.livedns.gandi.net/#quick-example), using the parts that have been implemented as Terraform resources.
-
+Note: sharing_id is optional. It is used e.g. when the API key is registered to a user, where the domain you want to manage is not registered with that user (but the user does have rights on that zone/organization). 
 ```
 provider "gandi" {
   key = "<the API key>"
+  sharing_id = "<the sharing_id>"
 }
 
 resource "gandi_zone" "example_com" {

--- a/gandi/provider.go
+++ b/gandi/provider.go
@@ -15,6 +15,13 @@ func Provider() *schema.Provider {
 				DefaultFunc: schema.EnvDefaultFunc("GANDI_KEY", nil),
 				Description: "A Gandi LiveDNS API key",
 			},
+			"sharing_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("GANDI_SHARING_ID", nil),
+				Description: "A Gandi LiveDNS sharing_id",
+			},
+	
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"gandi_zone":             resourceZone(),
@@ -26,6 +33,6 @@ func Provider() *schema.Provider {
 }
 
 func getGandiClient(d *schema.ResourceData) (interface{}, error) {
-	gandiClient := g.New(d.Get("key").(string))
+	gandiClient := g.New(d.Get("key").(string),d.Get("sharing_id").(string))
 	return gandiClient, nil
 }

--- a/gandi/provider.go
+++ b/gandi/provider.go
@@ -21,7 +21,6 @@ func Provider() *schema.Provider {
 				DefaultFunc: schema.EnvDefaultFunc("GANDI_SHARING_ID", nil),
 				Description: "A Gandi LiveDNS sharing_id",
 			},
-	
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"gandi_zone":             resourceZone(),
@@ -33,6 +32,6 @@ func Provider() *schema.Provider {
 }
 
 func getGandiClient(d *schema.ResourceData) (interface{}, error) {
-	gandiClient := g.New(d.Get("key").(string),d.Get("sharing_id").(string))
+	gandiClient := g.New(d.Get("key").(string), d.Get("sharing_id").(string))
 	return gandiClient, nil
 }


### PR DESCRIPTION
API keys are registered under a Gandi User account. Domains created outside this user account can't be properly managed by the API keys, unless a sharing_id is provided. E.g. creating and assigning a TSIG key to a domain can only be done if the TSIG key is created with the sharing_id as part of the request, and can only be added/listed to the domain if the sharing_id is again provided. 
It is entirely optional in the terraform 'provider' section to add, and optional when using the CLI version. 
Both terraform-provider-gandi and go-gandi-livedns and it's command line have been validated to work with this option. 