### PR TITLE
Homebrew formula

### DIFF
--- a/terraform-provider-gandi.rb
+++ b/terraform-provider-gandi.rb
@@ -1,0 +1,37 @@
+class TerraformProviderGandi < Formula
+  desc "Gandi provider for Terraform"
+  homepage "https://github.com/tiramiseb/terraform-provider-gandi"
+  url "https://github.com/tiramiseb/terraform-provider-gandi/archive/v1.1.0.tar.gz"
+  sha256 "e657882494a996c1ce530cb4e5b1677109a59381312c0de1eab56cab39be301e"
+  head "https://github.com/tiramiseb/terraform-provider-gandi.git"
+
+  depends_on "go" => :build
+  depends_on "terraform"
+
+  def install
+    ENV["GOPATH"] = buildpath
+
+    terrapath = buildpath/"src/github.com/tiramiseb/terraform-provider-gandi"
+    terrapath.install Dir["*"]
+
+    cd terrapath do
+      system "go", "build"
+      bin.install "terraform-provider-gandi"
+      prefix.install_metafiles
+    end
+  end
+
+  def caveats
+    <<~EOS
+      To enable this plugin, create or modify $HOME/.terraformrc with:
+
+      providers {
+        gandi = "#{HOMEBREW_PREFIX}/bin/terraform-provider-gandi"
+      }
+    EOS
+  end
+
+  test do
+    assert_match(/This binary is a plugin/, shell_output("#{bin}/terraform-provider-gandi 2>&1", 1))
+  end
+end


### PR DESCRIPTION
This is a formula file for homebrew.

It can be used either:

 * from a local clone: `brew install $(pwd)/terraform-provider-gandi.rb`
 * from a repo url: `brew install https://raw.githubusercontent.com/dubo-dubon-duponey/terraform-provider-gandi/homebrew/terraform-provider-gandi.rb` (<- obviously to be updated after merge)

However, to make it usable with the "fancy" tap syntax (eg: `brew install tiramiseb/FOO/terraform-provider-gandi`), it has to be hosted in a separate git repo (named `tiramiseb/homebrew-FOO`).

Finally, this file should be updated to always point to the latest release (possibly automating this in the makefile).