### PR TITLE
Fix for gandi_zone data provider returning the wrong zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ data "gandi_zone" "example_com" {
 }
 
 resource "gandi_zonerecord" "www" {
-  zone = "${gandi_zone.example_com.id}"
+  zone = "${data.gandi_zone.example_com.id}"
   name = "www"
   type = "A"
   ttl = 3600

--- a/gandi/data_zone.go
+++ b/gandi/data_zone.go
@@ -32,6 +32,7 @@ func dataSourceGandiZoneRead(d *schema.ResourceData, meta interface{}) error {
 	for _, zone := range zones {
 		if zone.Name == name {
 			found = &zone
+			break
 		}
 	}
 	if found == nil {


### PR DESCRIPTION
Thanks for this useful module. When using the `gandi_zone` data provider I noticed that it returns the wrong zone ID if you have multiple zones. It will always return the ID of the last zone as returned by the Gandi API, not the zone that matched the name (unless it is the last or only zone).

The fix is a missing `break` in the loop that iterates through the available zones. 

I've also fixed a missing `data.` prefix in the documentation.