### PR TITLE
ci&cd: improve automatic actions through github actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,37 +2,32 @@ name: Go
 on: [pull_request]
 jobs:
   build:
-    name: Build
+    name: Checks & Build
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.13
+    - name: Set up Go 1.14
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.14
       id: go
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1
 
-    - name: Get dependencies
-      run: |
-        go get -v -t -d ./...
- 
-    - name: Build
-      run: |
-        go build -v .
-        go vet ./...
-  
     - name: Format
       uses: sjkaliski/go-github-actions/fmt@v0.5.0
       env:
         GO_IGNORE_DIRS: "./vendor"
-    
+
     - name: Lint
       uses: sjkaliski/go-github-actions/lint@v0.5.0
       env:
         GO_LINT_PATHS: "./gandi/..."
-      
+
+    - name: Build
+      run: |
+        make
+
 # Disable the TF Provider Lint action until https://github.com/bflad/tfproviderlint-github-action/pull/1 is fixed
     # - name: TF Provider Lint
     #   uses: bflad/tfproviderlint-github-action@master

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,5 @@
 name: Go
-on: [pull_request]
+on: [push, pull_request]
 jobs:
   build:
     name: Checks & Build
@@ -12,7 +12,7 @@ jobs:
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Format
       uses: sjkaliski/go-github-actions/fmt@v0.5.0
@@ -24,12 +24,39 @@ jobs:
       env:
         GO_LINT_PATHS: "./gandi/..."
 
-    - name: Build
-      run: |
-        make
-
-# Disable the TF Provider Lint action until https://github.com/bflad/tfproviderlint-github-action/pull/1 is fixed
+    # Disable the TF Provider Lint action until https://github.com/bflad/tfproviderlint-github-action/pull/1 is fixed
     # - name: TF Provider Lint
     #   uses: bflad/tfproviderlint-github-action@master
     #   with:
     #     args: "./..."
+
+    - name: Build
+      run: |
+        make
+        go_version=$(go version)
+        os_arch=${go_version##*\ }
+        mv terraform-provider-gandi terraform-provider-gandi-${os_arch%%\/*}_${os_arch##*\/}
+        ls -la terraform-provider-gandi*
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: build-artifact
+        path: terraform-provider-gandi*
+  deploy:
+    name: Push artifact to Github release
+    if: github.event_name == 'push' && contains(github.ref, 'tags')
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - name: Download build artifact
+      uses: actions/download-artifact@v1
+      with:
+        name: build-artifact
+    - name: Upload binaries to github release
+      uses: svenstaro/upload-release-action@v1-release
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: build-artifact/terraform-provider-gandi*
+        tag: ${{ github.ref }}
+        overwrite: true
+        file_glob: true


### PR DESCRIPTION
This PR improves the automatic builds running on pull requests & push events.

- It uses the `make` command to build to provider (as advised by the README)
- It provides the built artifact via the Github artifact feature inside github actions
- deployment: on tagged push events it will automatically push the built artifact
  to the github release.
