### PR TITLE
Update build and release pipelines

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,16 +33,19 @@ jobs:
   
     - name: Format
       uses: sjkaliski/go-github-actions/fmt@v1.0.0
+      if: runner.os == 'Linux'
       env:
         GO_IGNORE_DIRS: "./vendor"
     
     - name: Lint
       uses: sjkaliski/go-github-actions/lint@v1.0.0
+      if: runner.os == 'Linux'
       env:
         GO_LINT_PATHS: "./gandi/..."
       
 #    - name: TF Provider Lint
 #      uses: bflad/tfproviderlint-github-action@master
+#      if: runner.os == 'Linux'
 #      with:
 #        args: "./..."
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,9 +1,22 @@
 name: Go
-on: [pull_request]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            asset_name: terraform-provider-gandi-linux_amd64
+          - os: macos-latest
+            asset_name: terraform-provider-gandi-darwin_amd64
+          - os: windows-latest
+            asset_name: terraform-provider-gandi-windows_amd64
     steps:
     - name: Set up Go 1.14
       uses: actions/setup-go@v1
@@ -28,7 +41,32 @@ jobs:
       env:
         GO_LINT_PATHS: "./gandi/..."
       
-    - name: TF Provider Lint
-      uses: bflad/tfproviderlint-github-action@master
+#    - name: TF Provider Lint
+#      uses: bflad/tfproviderlint-github-action@master
+#      with:
+#        args: "./..."
+
+    - uses: actions/upload-artifact/v2
+      name: Upload
       with:
-        args: "./..."
+        name: build-artifact
+        path: ${{ matrix.asset_name }}
+  deploy:
+    name: Push artifact as GitHub release
+    if: github.event.name == 'push' && contains(github.ref, 'tags')
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - name: Download built artifact
+      uses: actions/download-artifact/v1
+      with:
+        name: build-artifact
+    - name: Upload binaries to release
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: build-artifact/terraform-provider-gandi*
+        tag: ${{ github.ref }}
+        overwrite: true
+        file_glob: true
+

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -58,7 +58,7 @@ jobs:
     needs: build
     steps:
     - name: Download built artifact
-      uses: actions/download-artifact/v1
+      uses: actions/download-artifact@v1
       with:
         name: build-artifact
     - name: Upload binaries to release

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,36 +5,30 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.13
+    - name: Set up Go 1.14
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.14
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
-    - name: Get dependencies
-      run: |
-        go get -v -t -d ./...
- 
     - name: Build
       run: |
-        go build -v .
-        go vet ./...
+        make cibuild
   
     - name: Format
-      uses: sjkaliski/go-github-actions/fmt@v0.5.0
+      uses: sjkaliski/go-github-actions/fmt@v1.0.0
       env:
         GO_IGNORE_DIRS: "./vendor"
     
     - name: Lint
-      uses: sjkaliski/go-github-actions/lint@v0.5.0
+      uses: sjkaliski/go-github-actions/lint@v1.0.0
       env:
         GO_LINT_PATHS: "./gandi/..."
       
-# Disable the TF Provider Lint action until https://github.com/bflad/tfproviderlint-github-action/pull/1 is fixed
-    # - name: TF Provider Lint
-    #   uses: bflad/tfproviderlint-github-action@master
-    #   with:
-    #     args: "./..."
+    - name: TF Provider Lint
+      uses: bflad/tfproviderlint-github-action@master
+      with:
+        args: "./..."

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -42,7 +42,8 @@ jobs:
       if: runner.os == 'Linux'
       env:
         GO_LINT_PATHS: "./gandi/..."
-      
+
+# This still does something weird, comment out for now
 #    - name: TF Provider Lint
 #      uses: bflad/tfproviderlint-github-action@master
 #      if: runner.os == 'Linux'

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -46,7 +46,7 @@ jobs:
 #      with:
 #        args: "./..."
 
-    - uses: actions/upload-artifact/v2
+    - uses: actions/upload-artifact@v2
       name: Upload
       with:
         name: build-artifact

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .idea
-terraform-provider-gandi
+terraform-provider-gandi*
 *.tf
 *.tfstate*
 .terraform

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -6,7 +6,7 @@ GO_PLATFORM=$(subst /, ,$(word 4, $(shell go version)))
 
 default: build
 
-cibuild: vet fmt build
+cibuild: vet build
 	mv terraform-provider-gandi terraform-provider-gandi-$(word 1, $(GO_PLATFORM))_$(word 2, $(GO_PLATFORM))
 
 build: fmtcheck

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -2,8 +2,12 @@ TEST?=$$(go list ./... |grep -v 'vendor')
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 WEBSITE_REPO=github.com/hashicorp/terraform-website
 PKG_NAME=gandi
+GO_PLATFORM=$(subst /, ,$(word 4, $(shell go version)))
 
 default: build
+
+cibuild: vet fmt build
+	mv terraform-provider-gandi terraform-provider-gandi-$(word 1, $(GO_PLATFORM))_$(word 2, $(GO_PLATFORM))
 
 build: fmtcheck
 	go build -o terraform-provider-gandi

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -4,20 +4,20 @@ WEBSITE_REPO=github.com/hashicorp/terraform-website
 PKG_NAME=gandi
 GO_PLATFORM=$(subst /, ,$(word 4, $(shell go version)))
 
-default: build
+default: fmtcheck build
 
 cibuild: vet build
 	mv terraform-provider-gandi terraform-provider-gandi-$(word 1, $(GO_PLATFORM))_$(word 2, $(GO_PLATFORM))
 
-build: fmtcheck
+build:
 	go build -o terraform-provider-gandi
 
-test: fmtcheck
+test:
 	go test -i $(TEST) || exit 1
 	echo $(TEST) | \
 		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
 
-testacc: fmtcheck
+testacc:
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m
 
 vet:


### PR DESCRIPTION
This work builds off #33 and #23.

* [x] Update all current uses
* [x] Build binaries that are named per-platform
* [x] Upload binaries upon merge
* [x] Build binaries on Linux/Mac/Windows
* [x] Upload releases upon tags