### PR TITLE
fix domain data resource

### DIFF
--- a/gandi/data_domain.go
+++ b/gandi/data_domain.go
@@ -28,8 +28,5 @@ func dataSourceDomainRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	d.SetId(found.FQDN)
 	d.Set("name", found.FQDN)
-	if err = d.Set("nameservers", found.Nameservers); err != nil {
-		return fmt.Errorf("Failed to set nameservers for %s: %w", d.Id(), err)
-	}
 	return nil
 }


### PR DESCRIPTION
According https://api.gandi.net/docs/livedns/, the `/domains/{fqdn}` response object has no `NameServers` field.

Resolve #42 issue